### PR TITLE
Support configurable default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+ * 1.0.1 _Feb.05.2024_
+   * allow configurable default language
+ * 1.0.0 _May.24.2023_
+   * first release
  * 0.0.6 _May.24.2023_
    * add minimal template and koa/express examples to README
  * 0.0.5 _May.24.2023_

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ const csv = `
 `.slice(1, -1)
 
 // memoize csv to a function returning lang store and tuples
-const c = clak(csv)
+const c = clak(csv, 'en-US') // optional second param, default lang
 
-// lang store defines lang priority and col position each lang
+// lang store defines lang priority; number is lang col position
 // ex, [['en-US','ja-JP'], {'en-US': 2, 'ja-JP': 3}]
 const langs = c(['en-US','ja-JP'])
 

--- a/clak.test.js
+++ b/clak.test.js
@@ -87,3 +87,25 @@ test('should handle nested double quote', () => {
       'Validation failed, display name is already used ""{display_name}"".'
     ])
 })
+
+const csvNoEnglish = `
+"id","key","es-CL","ja-JP"
+1,"forbidden","you are forbidden","あなたが駄目です"
+2,"upstream_error","upstream error","それが駄目です"
+3,"access_denied","access denied","あなたが入れない駄目です"
+`.slice(1, -1)
+
+test('should allow configurable default language', () => {
+  // memoize csv to a function returning lang store and tuples
+  const c = clak(csvNoEnglish, 'ja-JP')
+
+  // lang store defines lang priority and col position each lang
+  const langs = c([ 'ja-JP', 'es-CL' ])
+
+  // tuple parsed row, uses scripted default when csv default missing
+  const access_denied = c('access_denied', 'no accesso')
+
+  assert.deepEqual(
+    clak(access_denied, langs, ['es-ES']),
+    'あなたが入れない駄目です')
+})

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clak",
   "type": "module",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "license": "ISC",
   "readmeFilename": "README.md",
   "description": "parses csv values to return internationalized messages",


### PR DESCRIPTION
clak can now be called with default second parameter that defines the default language used as fallback for failed lookups
```javascript
const c = clak(csv, 'en-US')
```